### PR TITLE
Fixed brands icons and width of date text fields in Mozilla

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this package will be documented in this file.
 
 The format os based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this package adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v1.0.4
+
+### Fixed
+
+- Fixed brands icons and width of date text fields in Mozilla
+
 ## v1.0.3
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@avto-dev/bank-card-vue-component",
-    "version": "1.0.3",
+    "version": "1.0.4",
     "description": "Vue Component - bank card",
     "author": "https://github.com/avto-dev",
     "license": "MIT",

--- a/src/components/VueBankCardBase.vue
+++ b/src/components/VueBankCardBase.vue
@@ -469,8 +469,7 @@ $field-invalid-outline-color: #df4242;
         }
 
         &-logo {
-            width: 100%;
-            max-height: 30px;
+            width: 40px;
 
             &-wrapper {
                 display: flex;

--- a/src/components/VueBankCardSmall.vue
+++ b/src/components/VueBankCardSmall.vue
@@ -469,6 +469,10 @@ $invalid-color: #df4242;
             justify-content: space-between;
             align-items: center;
         }
+
+        &-inner .card__field {
+            width: 22px;
+        }
     }
 
     &__cvv {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | Yes
| New feature?  | No

## Description

- Fixed brands icons and width of date text fields in Mozilla

<!--

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

-->

Fixes # (issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I wrote unit tests for my code
- [x] I have made changes in [CHANGELOG.md](https://github.com/avto-dev/bank-card-vue-component/blob/master/CHANGELOG.md) file

<!--

About your changes in `CHANGELOG.md`:

* Add new version header like `## UNRELEASED`, if it does not exists
* Add description under `added`/`changed`/`fixed` sections
* Add reference to closed issues `[#000]`
* Add link to issue in the end of document

-->
