### PR TITLE
Label isn't exist before input value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
+## Unreleased
+
+### Changed
+
+- Now a label from a field number isn't exist before how user become input
+some value with `is-new` prop
+
 ## v1.1.1
 
 ### Added

--- a/src/components/VueBankCardSmall.vue
+++ b/src/components/VueBankCardSmall.vue
@@ -33,15 +33,17 @@
             <div class="card__main-inner">
                 <div :class="cardNumberCssClasses">
                     <label
-                        v-if="isNew"
+                        v-if="isLabelInputShow"
+                        data-test-label-field-number
                         class="card__field-label"
                         :for="generateId('cardNumber')"
                     >
-                        {{ textLabelInput }}
+                        Номер карты
                     </label>
 
                     <input
                         v-show="!cardNumberCollapsed"
+                        data-test-input-field-number
                         class="card__field"
                         type="tel"
                         data-cp="cardNumber"
@@ -50,6 +52,7 @@
                         pattern="[ 0-9]*"
                         inputmode="numeric"
                         ref="cardNumber"
+                        :placeholder="textPlaceholderInput"
                         v-mask="cardNumberMask"
                         :value="cardNumber"
                         :id="generateId('cardNumber')"
@@ -240,10 +243,17 @@ export default {
     },
     computed: {
         /**
-         * Text for label
+         * Condition for show or don't show a label
          * @return {string}
          */
-        textLabelInput() {
+        isLabelInputShow() {
+            return this.isNew && !this.isFieldEmpty("cardNumber");
+        },
+        /**
+         * Text for placeholder
+         * @return {string}
+         */
+        textPlaceholderInput() {
             if (!this.cardFocused && this.isFieldEmpty("cardNumber")) {
                 return "Новая карта";
             }
@@ -599,6 +609,17 @@ $disabled-color: #e5e9ed;
                 overflow: hidden;
                 opacity: 0;
             }
+        }
+
+        &::placeholder {
+            font-size: 16px;
+            font-family: "PT Sans", "Arial", sans-serif;
+            line-height: 19px;
+            color: $base-color;
+        }
+
+        &:focus::placeholder {
+            color: $secondary-color;
         }
     }
 }

--- a/tests/components/vue-bank-card-small.test.js
+++ b/tests/components/vue-bank-card-small.test.js
@@ -36,38 +36,10 @@ describe("VueBankCardSmall", () => {
     describe("if isNew", () => {
         const labelSelector = ".card__number .card__field-label";
 
-        describe('label text', () => {
-            let wrapper = null;
-            let label = null;
-            beforeEach(() => {
-                const isNew = true;
-                wrapper = shallowMount(VueBankCardSmall, {
-                    propsData: {
-                        ...props,
-                        isNew
-                    }
-                });
-                label = wrapper.find('.card__field-label');
-            });
-
-            const defaultText = "Новая карта";
-            const nextStepText = "Номер карты";
-            it(`default text should be "${defaultText}"`, () => {
-                expect(label.text()).toBe(defaultText);
-            });
-
-            describe('if click on card container', () => {
-                it(`label text should be "${nextStepText}"`, async () => {
-                    const event = new Event("click");
-                    wrapper.element.dispatchEvent(event);
-                    await wrapper.vm.$nextTick();
-                    expect(label.text()).toBe(nextStepText);
-                });
-            });
-        });
-
         describe("is true", () => {
             let wrapper = null;
+            let label = null;
+            let input = null;
             beforeEach(() => {
                 const isNew = true;
                 wrapper = shallowMount(VueBankCardSmall, {
@@ -76,10 +48,29 @@ describe("VueBankCardSmall", () => {
                         isNew
                     }
                 });
+                label = wrapper.find("[data-test-label-field-number]");
+                input = wrapper.find("[data-test-input-field-number]");
             });
 
-            it("then show new card", () => {
-                expect(wrapper.find(labelSelector).isVisible()).toBeTruthy();
+            describe("placeholder text", () => {
+                const defaultText = "Новая карта";
+                const nextStepText = "Номер карты";
+                it(`default: placeholder on input should be "${defaultText}"`, () => {
+                    expect(input.element.placeholder).toBe(defaultText);
+                });
+
+                describe("if click on field card", () => {
+                    it(`label text should be "${nextStepText}"`, async () => {
+                        await wrapper.trigger("click");
+                        expect(input.element.placeholder).toBe(nextStepText);
+                    });
+                });
+            });
+
+            describe("label", () => {
+                it("default: label doesn't should exist", () => {
+                    expect(label.exists()).toBeFalsy();
+                });
             });
 
             it.each([
@@ -87,9 +78,7 @@ describe("VueBankCardSmall", () => {
                 ["year", "cc-exp-year"],
                 ["cvc", "cc-csc"]
             ])("then show %s input", (inputName, inputType) => {
-                const input = wrapper.find(
-                    `[autocomplete="${inputType}"]`
-                );
+                const input = wrapper.find(`[autocomplete="${inputType}"]`);
                 expect(input.isVisible()).toBeTruthy();
             });
         });


### PR DESCRIPTION
## Description

### Changed

- Now a label from a field number isn't exist before how user become input
some value with `is-new` prop

Fixes # (issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I wrote unit tests for my code _(if tests is required for my changes)_
- [x] I have made changes in `CHANGELOG.md` file

<!--

About your changes in `CHANGELOG.md`:

* Add new version header like `## v1.x.x` or `## UNRELEASED`, if it does not exists
* Add description under `added`/`changed`/`fixed` sections
* Add reference to closed issues `[#000]`
* Add link to issue in the end of document

-->
